### PR TITLE
[2.0.0] metrics

### DIFF
--- a/src/bagel_factor/__init__.py
+++ b/src/bagel_factor/__init__.py
@@ -1,1 +1,2 @@
 from .data_handling import *
+from .metrics import *

--- a/src/bagel_factor/metrics/__init__.py
+++ b/src/bagel_factor/metrics/__init__.py
@@ -1,0 +1,1 @@
+from .ic import information_coefficient

--- a/src/bagel_factor/metrics/__init__.py
+++ b/src/bagel_factor/metrics/__init__.py
@@ -1,1 +1,3 @@
 from .ic import information_coefficient
+from .quantile_returns import quantile_returns, quantile_spread
+from .risk_metrics import *

--- a/src/bagel_factor/metrics/ic.py
+++ b/src/bagel_factor/metrics/ic.py
@@ -1,0 +1,41 @@
+
+import pandas as pd
+from typing import Literal, Optional
+
+
+def information_coefficient(factor: pd.Series,
+                            returns: pd.Series,
+                            method: Literal['pearson', 'spearman'] = 'pearson',
+                            min_periods: int = 3) -> pd.Series:
+    """
+    Compute the Information Coefficient (IC) between factor and future returns, grouped by date.
+    IC is the cross-sectional correlation (Pearson or Spearman) between factor and returns for each date.
+
+    Parameters
+    ----------
+    factor: pd.Series 
+        with MultiIndex (date, ticker)
+    returns: pd.Series
+        with MultiIndex (date, ticker)
+    method: Literal['pearson', 'spearman']
+        Default 'pearson'. Correlation method to use.
+    min_periods: int
+        minimum number of pairs to compute correlation
+    Returns
+    -------
+    pd.Series
+        IC values indexed by date
+    """
+    if not factor.index.equals(returns.index):
+        raise ValueError("Indices of factor and returns must match.")
+    if method not in ('pearson', 'spearman'):
+        raise ValueError("method must be 'pearson' or 'spearman'")
+    df = pd.DataFrame({'factor': factor, 'returns': returns})
+    def compute_ic(group):
+        # If all values are nan or constant, corr returns nan
+        if group['factor'].nunique(dropna=True) <= 1 or group['returns'].nunique(dropna=True) <= 1:
+            return float('nan')
+        return group['factor'].corr(group['returns'], method=method, min_periods=min_periods)
+    ic_series = df.groupby(df.index.get_level_values('date')).apply(compute_ic)
+    ic_series.name = f'IC_{method}'
+    return ic_series

--- a/src/bagel_factor/metrics/ic.py
+++ b/src/bagel_factor/metrics/ic.py
@@ -1,10 +1,10 @@
 
 import pandas as pd
-from typing import Literal, Optional
+from typing import Literal
 
 
 def information_coefficient(factor: pd.Series,
-                            returns: pd.Series,
+                            future_returns: pd.Series,
                             method: Literal['pearson', 'spearman'] = 'pearson',
                             min_periods: int = 3) -> pd.Series:
     """
@@ -15,8 +15,8 @@ def information_coefficient(factor: pd.Series,
     ----------
     factor: pd.Series 
         with MultiIndex (date, ticker)
-    returns: pd.Series
-        with MultiIndex (date, ticker)
+    future_returns: pd.Series
+        with MultiIndex (date, ticker), notice that this is future returns, not past returns (Avoid lookahead bias)
     method: Literal['pearson', 'spearman']
         Default 'pearson'. Correlation method to use.
     min_periods: int
@@ -26,11 +26,11 @@ def information_coefficient(factor: pd.Series,
     pd.Series
         IC values indexed by date
     """
-    if not factor.index.equals(returns.index):
+    if not factor.index.equals(future_returns.index):
         raise ValueError("Indices of factor and returns must match.")
     if method not in ('pearson', 'spearman'):
         raise ValueError("method must be 'pearson' or 'spearman'")
-    df = pd.DataFrame({'factor': factor, 'returns': returns})
+    df = pd.DataFrame({'factor': factor, 'returns': future_returns})
     def compute_ic(group):
         # If all values are nan or constant, corr returns nan
         if group['factor'].nunique(dropna=True) <= 1 or group['returns'].nunique(dropna=True) <= 1:

--- a/src/bagel_factor/metrics/ic.py
+++ b/src/bagel_factor/metrics/ic.py
@@ -3,10 +3,12 @@ import pandas as pd
 from typing import Literal
 
 
-def information_coefficient(factor: pd.Series,
-                            future_returns: pd.Series,
-                            method: Literal['pearson', 'spearman'] = 'pearson',
-                            min_periods: int = 3) -> pd.Series:
+def information_coefficient(
+    factor: pd.Series,
+    future_returns: pd.Series,
+    method: Literal['pearson', 'spearman'] = 'pearson',
+    min_periods: int = 3
+) -> pd.Series:
     """
     Compute the Information Coefficient (IC) between factor and future returns, grouped by date.
     IC is the cross-sectional correlation (Pearson or Spearman) between factor and returns for each date.

--- a/src/bagel_factor/metrics/quantile_returns.py
+++ b/src/bagel_factor/metrics/quantile_returns.py
@@ -1,0 +1,89 @@
+
+import pandas as pd
+import numpy as np
+from typing import Optional, Union
+
+def quantile_returns(
+    factor: pd.Series,
+    returns: pd.Series,
+    n_quantiles: int = 10,
+    quantile_labels: Optional[Union[list, None]] = None,
+    min_periods: int = 1,
+    quantile_range: Optional[tuple] = None
+) -> pd.DataFrame:
+    """
+    Compute mean future returns for each factor quantile, grouped by date.
+
+    Parameters
+    ----------
+    factor: pd.Series
+        with MultiIndex (date, ticker)
+    returns: pd.Series
+        with MultiIndex (date, ticker)
+    n_quantiles: int
+        Number of quantile bins (default 10)
+    quantile_labels: list or None
+        Custom labels for quantiles (default None, uses 1..n_quantiles)
+    min_periods: int
+        Minimum number of stocks in a quantile to compute mean return (default 1)
+    quantile_range: tuple or None
+        (min, max) range for quantile calculation (default None, uses full range)
+    Returns
+    -------
+    pd.DataFrame
+        index: date, columns: quantile label, values: mean return for each quantile/date
+    """
+    if not factor.index.equals(returns.index):
+        raise ValueError("Indices of factor and returns must match.")
+    if quantile_labels is None:
+        quantile_labels = list(range(1, n_quantiles + 1))
+    df = pd.DataFrame({'factor': factor, 'returns': returns})
+    def assign_quantile(x):
+        # If all values are nan or constant, assign all to middle quantile
+        if x['factor'].nunique(dropna=True) <= 1:
+            return pd.Series([quantile_labels[n_quantiles // 2]] * len(x), index=x.index)
+        return pd.qcut(
+            x['factor'],
+            q=n_quantiles,
+            labels=quantile_labels,
+            duplicates='drop',
+            # quantile_range is not a pd.qcut arg, but could be used for custom logic
+        )
+    df['quantile'] = df.groupby(df.index.get_level_values('date'), group_keys=False).apply(assign_quantile)
+    # Compute mean returns for each quantile/date, only if enough non-nan values
+    def mean_with_min(x):
+        if x.notna().sum() < min_periods:
+            return np.nan
+        return x.mean()
+    result = df.groupby([df.index.get_level_values('date'), 'quantile'])['returns'].apply(mean_with_min).unstack('quantile')
+    return result
+
+def quantile_spread(
+    quantile_returns_df: pd.DataFrame,
+    upper: Optional[Union[int, str]] = None,
+    lower: Optional[Union[int, str]] = None
+) -> pd.Series:
+    """
+    Compute the spread between upper and lower quantile returns for each date.
+    By default, uses the highest and lowest quantiles.
+
+    Parameters
+    ----------
+    quantile_returns_df: pd.DataFrame
+        Output of quantile_returns (index: date, columns: quantile)
+    upper: int or str or None
+        Column label for upper quantile (default: max column)
+    lower: int or str or None
+        Column label for lower quantile (default: min column)
+    Returns
+    -------
+    pd.Series
+        index: date, values: upper - lower quantile return
+    """
+    if upper is None:
+        upper = quantile_returns_df.columns.max()
+    if lower is None:
+        lower = quantile_returns_df.columns.min()
+    spread = quantile_returns_df[upper] - quantile_returns_df[lower]
+    spread.name = 'quantile_spread'
+    return spread

--- a/src/bagel_factor/metrics/risk_metrics.py
+++ b/src/bagel_factor/metrics/risk_metrics.py
@@ -83,7 +83,7 @@ def sharpe_ratio(
         Risk-free rate per period, in the same return type as `returns`.
     periods_per_year : int, default 252
         Number of periods in a year (e.g., 252 for daily returns).
-    return_type : {'log', 'normal'}, default 'normal'
+    return_type : {'log', 'normal'}, default 'log'
         Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
 
     Returns
@@ -123,7 +123,7 @@ def max_drawdown(
     ----------
     returns : pd.Series
         Periodic returns (log or normal, as specified by `return_type`).
-    return_type : {'log', 'normal'}, default 'normal'
+    return_type : {'log', 'normal'}, default 'log'
         Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
 
     Returns
@@ -151,7 +151,7 @@ def calmar_ratio(
         Periodic returns (log or normal, as specified by `return_type`).
     periods_per_year : int, default 252
         Number of periods in a year (e.g., 252 for daily returns).
-    return_type : {'log', 'normal'}, default 'normal'
+    return_type : {'log', 'normal'}, default 'log'
         Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
 
     Returns
@@ -229,7 +229,7 @@ def sortino_ratio(
         Risk-free rate per period, in the same return type as `returns`.
     periods_per_year : int, default 252
         Number of periods in a year (e.g., 252 for daily returns).
-    return_type : {'log', 'normal'}, default 'normal'
+    return_type : {'log', 'normal'}, default 'log'
         Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
 
     Returns

--- a/src/bagel_factor/metrics/risk_metrics.py
+++ b/src/bagel_factor/metrics/risk_metrics.py
@@ -1,0 +1,248 @@
+import numpy as np
+import pandas as pd
+from typing import Literal
+
+def accumulate_return(
+    returns: pd.Series, 
+    return_type: Literal['log', 'normal'] = 'log'
+) -> pd.Series:
+    """
+    Accumulate returns to get the cumulative return series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    return_type : {'log', 'normal'}, default 'log'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    pd.Series
+        Cumulative return series.
+    """
+    if return_type == 'log':
+        return returns.cumsum().apply(np.exp)
+    else:
+        return (1 + returns).cumprod()
+
+def annualized_volatility(
+    returns: pd.Series, 
+    periods_per_year: int = 252, 
+    return_type: Literal['log', 'normal'] = 'log',
+) -> float:
+    """
+    Calculate the annualized volatility of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    periods_per_year : int, default 252
+        Number of periods in a year (e.g., 252 for daily returns).
+    return_type : {'log', 'normal'}, default 'log'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Annualized volatility.
+    """
+    if returns.empty or returns.isna().all():
+        return np.nan
+    if return_type == 'log':
+        return returns.std(ddof=1) * np.sqrt(periods_per_year)
+    else:
+        return returns.std(ddof=1) * np.sqrt(periods_per_year)
+
+
+def sharpe_ratio(
+    returns: pd.Series, 
+    risk_free_rate: float = 0.0, 
+    periods_per_year: int = 252, 
+    return_type: Literal['log', 'normal'] = 'log'
+) -> float:
+    """
+    Calculate the annualized Sharpe ratio of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    risk_free_rate : float, default 0.0
+        Risk-free rate per period, in the same return type as `returns`.
+    periods_per_year : int, default 252
+        Number of periods in a year (e.g., 252 for daily returns).
+    return_type : {'log', 'normal'}, default 'normal'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Annualized Sharpe ratio.
+    """
+    excess_returns = returns - risk_free_rate
+    if returns.empty or returns.isna().all():
+        return np.nan
+    if return_type == 'log':
+        ann_excess_return: float = excess_returns.mean() * periods_per_year
+    else:
+        prod_result = (1 + excess_returns).prod()
+        if isinstance(prod_result, complex):
+            base = float(prod_result.real)
+        else:
+            try:
+                base = float(pd.to_numeric(prod_result, errors='coerce'))
+            except Exception:
+                base = float('nan')
+        ann_excess_return: float = base ** (periods_per_year / len(returns)) - 1
+    ann_vol = annualized_volatility(returns, periods_per_year, return_type=return_type)
+    if ann_vol == 0:
+        return np.nan
+    return ann_excess_return / ann_vol
+
+
+def max_drawdown(
+    returns: pd.Series, 
+    return_type: Literal['log', 'normal'] = 'log'
+) -> float:
+    """
+    Calculate the maximum drawdown of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    return_type : {'log', 'normal'}, default 'normal'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Maximum drawdown (as a negative number).
+    """
+    cumulative = accumulate_return(returns, return_type=return_type)
+    peak = cumulative.cummax()
+    drawdown = cumulative / peak - 1
+    return drawdown.min()
+
+
+def calmar_ratio(
+    returns: pd.Series, 
+    periods_per_year: int = 252, 
+    return_type: Literal['log', 'normal'] = 'log'
+) -> float:
+    """
+    Calculate the Calmar ratio of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    periods_per_year : int, default 252
+        Number of periods in a year (e.g., 252 for daily returns).
+    return_type : {'log', 'normal'}, default 'normal'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Calmar ratio.
+    """
+    if returns.empty or returns.isna().all():
+        return np.nan
+    if return_type == 'log':
+        ann_return = returns.mean() * periods_per_year
+    else:
+        prod_result = (1 + returns).prod()
+        if isinstance(prod_result, complex):
+            base = float(prod_result.real)
+        else:
+            try:
+                base = float(pd.to_numeric(prod_result, errors='coerce'))
+            except Exception:
+                base = float('nan')
+        ann_return = base ** (periods_per_year / len(returns)) - 1
+    mdd = abs(max_drawdown(returns, return_type=return_type))
+    if mdd == 0:
+        return np.nan
+    return ann_return / mdd
+
+
+def downside_risk(
+    returns: pd.Series, 
+    risk_free_rate: float = 0.0, 
+    periods_per_year: int = 252, 
+    return_type: Literal['log', 'normal'] = 'log'
+) -> float:
+    """
+    Calculate the annualized downside risk of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    risk_free_rate : float, default 0.0
+        Risk-free rate per period, in the same return type as `returns`.
+    periods_per_year : int, default 252
+        Number of periods in a year (e.g., 252 for daily returns).
+    return_type : {'log', 'normal'}, default 'log'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Annualized downside risk.
+    """
+    if returns.empty or returns.isna().all():
+        return np.nan
+    downside = returns[returns < risk_free_rate] - risk_free_rate
+    if downside.empty:
+        return 0.0
+    downside_std = downside.std(ddof=1)
+    return downside_std * np.sqrt(periods_per_year)
+
+
+def sortino_ratio(
+    returns: pd.Series, 
+    risk_free_rate: float = 0.0, 
+    periods_per_year: int = 252, 
+    return_type: Literal['log', 'normal'] = 'log') -> float:
+    """
+    Calculate the annualized Sortino ratio of a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Periodic returns (log or normal, as specified by `return_type`).
+    risk_free_rate : float, default 0.0
+        Risk-free rate per period, in the same return type as `returns`.
+    periods_per_year : int, default 252
+        Number of periods in a year (e.g., 252 for daily returns).
+    return_type : {'log', 'normal'}, default 'normal'
+        Type of returns provided. If 'log', input is log returns. If 'normal', input is arithmetic returns.
+
+    Returns
+    -------
+    float
+        Annualized Sortino ratio.
+    """
+    excess_returns = returns - risk_free_rate
+    if returns.empty or returns.isna().all():
+        return np.nan
+    if return_type == 'log':
+        ann_excess_return = excess_returns.mean() * periods_per_year
+    else:
+        prod_result = (1 + excess_returns).prod()
+        if isinstance(prod_result, complex):
+            base = float(prod_result.real)
+        else:
+            try:
+                base = float(pd.to_numeric(prod_result, errors='coerce'))
+            except Exception:
+                base = float('nan')
+        ann_excess_return = base ** (periods_per_year / len(returns)) - 1
+    drisk = downside_risk(returns, risk_free_rate, periods_per_year, return_type=return_type)
+    if drisk == 0:
+        return np.nan
+    return ann_excess_return / drisk

--- a/src/bagel_factor/metrics/risk_metrics.py
+++ b/src/bagel_factor/metrics/risk_metrics.py
@@ -2,6 +2,16 @@ import numpy as np
 import pandas as pd
 from typing import Literal
 
+__all__ = [
+    'accumulate_return',
+    'annualized_volatility',
+    'sharpe_ratio',
+    'max_drawdown',
+    'calmar_ratio',
+    'downside_risk',
+    'sortino_ratio'
+]
+
 def accumulate_return(
     returns: pd.Series, 
     return_type: Literal['log', 'normal'] = 'log'

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -1,0 +1,57 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.bagel_factor.metrics import ic
+
+class TestInformationCoefficient(unittest.TestCase):
+    def setUp(self):
+        # 3 dates, 4 tickers
+        dates = pd.date_range('2023-01-01', periods=3)
+        tickers = ['A', 'B', 'C', 'D']
+        idx = pd.MultiIndex.from_product([dates, tickers], names=['date', 'ticker'])
+        # Factor and returns are perfectly correlated
+        self.factor = pd.Series(np.tile([1, 2, 3, 4], 3), index=idx, name='factor')
+        self.returns = pd.Series(np.tile([10, 20, 30, 40], 3), index=idx, name='returns')
+        # Add a constant group for edge case
+        self.factor_const = self.factor.copy()
+        self.factor_const.loc[(dates[0], slice(None))] = 5.0
+        self.returns_const = self.returns.copy()
+        self.returns_const.loc[(dates[1], slice(None))] = 7.0
+        # Add NaNs
+        self.factor_nan = self.factor.copy()
+        self.factor_nan.loc[(dates[2], 'A')] = np.nan
+        self.returns_nan = self.returns.copy()
+        self.returns_nan.loc[(dates[2], 'B')] = np.nan
+
+    def test_ic_pearson_perfect(self):
+        ic_series = ic.information_coefficient(self.factor, self.returns, method='pearson')
+        self.assertTrue(np.allclose(ic_series, 1.0, equal_nan=False))
+        print(ic_series)
+
+    def test_ic_spearman_perfect(self):
+        ic_series = ic.information_coefficient(self.factor, self.returns, method='spearman')
+        self.assertTrue(np.allclose(ic_series, 1.0, equal_nan=False))
+        print(ic_series)
+
+    def test_ic_with_constant_group(self):
+        ic_series = ic.information_coefficient(self.factor_const, self.returns, method='pearson')
+        self.assertTrue(np.isnan(ic_series.iloc[0]))  # First date is constant
+        self.assertFalse(np.isnan(ic_series.iloc[1:]).any())
+        ic_series2 = ic.information_coefficient(self.factor, self.returns_const, method='pearson')
+        self.assertTrue(np.isnan(ic_series2.iloc[1]))  # Second date is constant
+
+    def test_ic_with_nan(self):
+        ic_series = ic.information_coefficient(self.factor_nan, self.returns_nan, method='pearson')
+        self.assertEqual(len(ic_series), 3)
+        self.assertFalse(ic_series.isnull().all())
+
+    def test_index_mismatch(self):
+        with self.assertRaises(ValueError):
+            ic.information_coefficient(self.factor, self.returns.drop(self.returns.index[0]))
+
+    def test_invalid_method(self):
+        with self.assertRaises(ValueError):
+            ic.information_coefficient(self.factor, self.returns, method='kendall')  # type: ignore
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_quantile_returns.py
+++ b/tests/test_quantile_returns.py
@@ -1,0 +1,56 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.bagel_factor.metrics import quantile_returns
+
+class TestQuantileReturns(unittest.TestCase):
+    def setUp(self):
+        # 3 dates, 6 tickers
+        dates = pd.date_range('2023-01-01', periods=3)
+        tickers = ['A', 'B', 'C', 'D', 'E', 'F']
+        idx = pd.MultiIndex.from_product([dates, tickers], names=['date', 'ticker'])
+        # Factor: 1-6 repeated for each date
+        self.factor = pd.Series(np.tile(np.arange(1, 7), 3), index=idx, name='factor')
+        # Returns: 10-60 repeated for each date
+        self.returns = pd.Series(np.tile(np.arange(10, 70, 10), 3), index=idx, name='returns')
+        # Constant factor for first date
+        self.factor_const = self.factor.copy()
+        self.factor_const.loc[(dates[0], slice(None))] = 5.0
+        # NaN in returns for last date
+        self.returns_nan = self.returns.copy()
+        self.returns_nan.loc[(dates[2], 'A')] = np.nan
+
+    def test_quantile_returns_basic(self):
+        qrets = quantile_returns.quantile_returns(self.factor, self.returns, n_quantiles=3)
+        print(qrets)
+        self.assertEqual(qrets.shape, (3, 3))
+        # For perfect monotonic, each quantile should have 2 stocks per date
+        for d in qrets.index:
+            self.assertFalse(qrets.loc[d].isnull().any())
+            self.assertTrue(np.allclose(qrets.loc[d].values, [15, 35, 55]))
+
+    def test_quantile_returns_custom_labels(self):
+        qrets = quantile_returns.quantile_returns(self.factor, self.returns, n_quantiles=2, quantile_labels=['low', 'high'])
+        self.assertListEqual(list(qrets.columns), ['low', 'high'])
+
+    def test_quantile_returns_constant(self):
+        qrets = quantile_returns.quantile_returns(self.factor_const, self.returns, n_quantiles=3)
+        # All assigned to middle quantile for first date
+        self.assertTrue((qrets.loc[qrets.index[0]].dropna().index == 2).all())
+
+    def test_quantile_returns_nan(self):
+        qrets = quantile_returns.quantile_returns(self.factor, self.returns_nan, n_quantiles=3)
+        print(qrets)
+
+    def test_quantile_spread(self):
+        qrets = quantile_returns.quantile_returns(self.factor, self.returns, n_quantiles=3)
+        spread = quantile_returns.quantile_spread(qrets)
+        print(spread)
+        self.assertTrue(np.allclose(spread, 40))
+
+    def test_index_mismatch(self):
+        with self.assertRaises(ValueError):
+            quantile_returns.quantile_returns(self.factor, self.returns.drop(self.returns.index[0]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -1,0 +1,84 @@
+import unittest
+import numpy as np
+import pandas as pd
+from src.bagel_factor.metrics import risk_metrics
+
+class TestRiskMetrics(unittest.TestCase):
+    def setUp(self):
+        # Simulate daily returns for 2 years (504 trading days)
+        np.random.seed(42)
+        self.returns_normal = pd.Series(np.random.normal(0.001, 0.01, 504))
+        self.returns_log = pd.Series(np.log1p(self.returns_normal), index=self.returns_normal.index)
+        self.risk_free_rate = 0.0001
+        self.periods_per_year = 252
+
+    def test_accumulate_return_normal(self):
+        cum = risk_metrics.accumulate_return(self.returns_normal, return_type='normal')
+        self.assertAlmostEqual(cum.iloc[0], 1 + self.returns_normal.iloc[0], places=6)
+        self.assertTrue(np.all(cum > 0))
+        print("Cumulative Normal Returns:", cum.head())
+
+    def test_accumulate_return_log(self):
+        cum = risk_metrics.accumulate_return(self.returns_log, return_type='log')
+        self.assertAlmostEqual(cum.iloc[0], np.exp(self.returns_log.iloc[0]), places=6)
+        self.assertTrue(np.all(cum > 0))
+        print("Cumulative Log Returns:", cum.head())
+
+    def test_annualized_volatility(self):
+        vol_log = risk_metrics.annualized_volatility(self.returns_log, self.periods_per_year, 'log')
+        vol_normal = risk_metrics.annualized_volatility(self.returns_normal, self.periods_per_year, 'normal')
+        self.assertGreater(vol_log, 0)
+        self.assertGreater(vol_normal, 0)
+        print("Annualized Volatility (Log):", vol_log)
+        print("Annualized Volatility (Normal):", vol_normal)
+
+    def test_sharpe_ratio(self):
+        sr_log = risk_metrics.sharpe_ratio(self.returns_log, self.risk_free_rate, self.periods_per_year, 'log')
+        sr_normal = risk_metrics.sharpe_ratio(self.returns_normal, self.risk_free_rate, self.periods_per_year, 'normal')
+        self.assertIsInstance(sr_log, float)
+        self.assertIsInstance(sr_normal, float)
+        print("Sharpe Ratio (Log):", sr_log)
+        print("Sharpe Ratio (Normal):", sr_normal)
+
+    def test_max_drawdown(self):
+        mdd_log = risk_metrics.max_drawdown(self.returns_log, 'log')
+        mdd_normal = risk_metrics.max_drawdown(self.returns_normal, 'normal')
+        self.assertLessEqual(mdd_log, 0)
+        self.assertLessEqual(mdd_normal, 0)
+        print("Max Drawdown (Log):", mdd_log)
+        print("Max Drawdown (Normal):", mdd_normal)
+
+    def test_calmar_ratio(self):
+        calmar_log = risk_metrics.calmar_ratio(self.returns_log, self.periods_per_year, 'log')
+        calmar_normal = risk_metrics.calmar_ratio(self.returns_normal, self.periods_per_year, 'normal')
+        self.assertIsInstance(calmar_log, float)
+        self.assertIsInstance(calmar_normal, float)
+        print("Calmar Ratio (Log):", calmar_log)
+        print("Calmar Ratio (Normal):", calmar_normal)
+
+    def test_downside_risk(self):
+        dr_log = risk_metrics.downside_risk(self.returns_log, self.risk_free_rate, self.periods_per_year, 'log')
+        dr_normal = risk_metrics.downside_risk(self.returns_normal, self.risk_free_rate, self.periods_per_year, 'normal')
+        self.assertGreaterEqual(dr_log, 0)
+        self.assertGreaterEqual(dr_normal, 0)
+        print("Downside Risk (Log):", dr_log)
+        print("Downside Risk (Normal):", dr_normal)
+
+    def test_sortino_ratio(self):
+        sortino_log = risk_metrics.sortino_ratio(self.returns_log, self.risk_free_rate, self.periods_per_year, 'log')
+        sortino_normal = risk_metrics.sortino_ratio(self.returns_normal, self.risk_free_rate, self.periods_per_year, 'normal')
+        self.assertIsInstance(sortino_log, float)
+        self.assertIsInstance(sortino_normal, float)
+        print("Sortino Ratio (Log):", sortino_log)
+        print("Sortino Ratio (Normal):", sortino_normal)
+
+    def test_empty_returns(self):
+        empty = pd.Series(dtype=float)
+        self.assertTrue(np.isnan(risk_metrics.annualized_volatility(empty, self.periods_per_year, 'log')))
+        self.assertTrue(np.isnan(risk_metrics.sharpe_ratio(empty, self.risk_free_rate, self.periods_per_year, 'log')))
+        self.assertTrue(np.isnan(risk_metrics.calmar_ratio(empty, self.periods_per_year, 'log')))
+        self.assertTrue(np.isnan(risk_metrics.downside_risk(empty, self.risk_free_rate, self.periods_per_year, 'log')))
+        self.assertTrue(np.isnan(risk_metrics.sortino_ratio(empty, self.risk_free_rate, self.periods_per_year, 'log')))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request adds a comprehensive set of financial metrics and their corresponding unit tests to the `bagel_factor` package, significantly expanding its quantitative analysis capabilities. The changes include the implementation of information coefficient calculations, quantile returns analysis, and a suite of risk metrics commonly used in finance. All new modules are exposed via the package's public API, and robust unit tests are provided for each metric to ensure correctness and handle edge cases.

**New financial metrics implementations:**

* Added `information_coefficient` function to compute cross-sectional correlation between a factor and future returns, supporting both Pearson and Spearman methods.
* Implemented `quantile_returns` and `quantile_spread` functions to analyze mean returns by factor quantile and compute spreads between quantiles.
* Introduced a suite of risk metrics: cumulative return, annualized volatility, Sharpe ratio, max drawdown, Calmar ratio, downside risk, and Sortino ratio, with support for both log and normal returns.

**API and package structure updates:**

* Updated `src/bagel_factor/__init__.py` and `src/bagel_factor/metrics/__init__.py` to expose new metrics modules and functions through the package API. [[1]](diffhunk://#diff-f5cff42a09566c194e3cb671cf023e4c65461143e62c7599ac89ec8084a47be9R2) [[2]](diffhunk://#diff-99ae58d50cc44540cbcb63e5f4e03b9a8c08b60c3b05811bbfd9d903f6327052R1)

**Unit tests for new metrics:**

* Added `tests/test_ic.py` to test the information coefficient, including edge cases like constant and NaN groups.
* Added `tests/test_quantile_returns.py` to test quantile returns and spread calculations, including custom labels and NaN handling.
* Added `tests/test_risk_metrics.py` to test all risk metrics functions, covering both log and normal returns, and handling of empty input.