### PR TITLE
[0.1.2] efficiency improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It intentionally does **not** implement multi-factor modeling or portfolio backt
 
 ## Install
 
+Requires Python >=3.12
+
 ```bash
 pip install bagel-factor
 ```

--- a/docs/modules/data/universe.md
+++ b/docs/modules/data/universe.md
@@ -23,6 +23,8 @@ A lightweight object holding the mask (and labels).
 
 ## `Universe.apply(panel) -> pd.DataFrame`
 
+Note: Universe masks are reindexed to match the panel and missing entries are treated as False to avoid unintentionally dropping rows.
+
 Filters a panel down to rows where `mask == True`.
 
 ### Logic

--- a/examples/benchmark_ic.py
+++ b/examples/benchmark_ic.py
@@ -1,0 +1,102 @@
+"""Benchmark script for ic_series and coverage_by_date.
+
+Generates synthetic panels and compares the current vectorized implementations
+against groupby.apply baselines.
+"""
+
+import time
+import numpy as np
+import pandas as pd
+from bagelfactor.metrics.ic import ic_series
+from bagelfactor.metrics.coverage import coverage_by_date
+
+
+def baseline_ic(panel, factor, label, method="spearman"):
+    df = panel[[factor, label]].dropna()
+
+    def _ic(g: pd.DataFrame) -> float:
+        if len(g) < 2:
+            return float("nan")
+        x = g[factor]
+        y = g[label]
+        if method == "spearman":
+            x = x.rank(method="average")
+            y = y.rank(method="average")
+        return float(x.corr(y, method="pearson"))
+
+    return df.groupby(level="date", sort=False).apply(_ic).rename("ic")
+
+
+def baseline_coverage(panel, column):
+    s = panel[column]
+
+    def _cov(x: pd.Series) -> float:
+        return float(x.notna().mean()) if len(x) else float("nan")
+
+    return s.groupby(level="date", sort=False).apply(_cov).rename("coverage")
+
+
+def make_panel(n_dates, n_assets, na_prob=0.05, seed=0):
+    rng = np.random.RandomState(seed)
+    dates = pd.date_range("2020-01-01", periods=n_dates, freq="D")
+    assets = [f"A{i}" for i in range(n_assets)]
+    mi = pd.MultiIndex.from_product([dates, assets], names=["date", "asset"])
+    size = n_dates * n_assets
+    factor = rng.randn(size)
+    label = rng.randn(size)
+    mask = rng.rand(size) < na_prob
+    factor[mask] = np.nan
+    mask2 = rng.rand(size) < na_prob
+    label[mask2] = np.nan
+    df = pd.DataFrame({"factor": factor, "label": label}, index=mi)
+    return df
+
+
+def time_function(fn, *args, repeats=3):
+    times = []
+    result = None
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        res = fn(*args)
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
+        result = res
+    return min(times), np.median(times), result
+
+
+if __name__ == "__main__":
+    sizes = [(200, 100), (500, 200)]  # (n_dates, n_assets)
+    for n_dates, n_assets in sizes:
+        print(f"\nPanel size: dates={n_dates}, assets={n_assets} (rows={n_dates*n_assets})")
+        panel = make_panel(n_dates, n_assets, na_prob=0.05, seed=42)
+
+        # IC benchmark
+        print("Benchmarking IC...")
+        base_min, base_med, base_res = time_function(baseline_ic, panel, "factor", "label", "spearman", repeats=3)
+        vec_min, vec_med, vec_res = time_function(lambda p: ic_series(p, factor="factor", label="label", method="spearman"), panel, repeats=3)
+
+        # align results for comparison
+        base_res = base_res.sort_index()
+        vec_res = vec_res.sort_index()
+        # Compare finite entries
+        common_idx = base_res.index.intersection(vec_res.index)
+        diffs = (base_res.loc[common_idx].fillna(0) - vec_res.loc[common_idx].fillna(0)).abs()
+        max_diff = diffs.max() if len(diffs) else float('nan')
+
+        print(f"IC baseline min/med: {base_min:.4f}s / {base_med:.4f}s")
+        print(f"IC vector min/med:   {vec_min:.4f}s / {vec_med:.4f}s")
+        print(f"IC max abs diff: {max_diff}")
+
+        # Coverage benchmark
+        print("Benchmarking coverage...")
+        base_min, base_med, base_res = time_function(baseline_coverage, panel, "factor", repeats=3)
+        vec_min, vec_med, vec_res = time_function(lambda p: coverage_by_date(p, column="factor"), panel, repeats=3)
+
+        base_res = base_res.sort_index()
+        vec_res = vec_res.sort_index()
+        diffs = (base_res - vec_res).abs()
+        max_diff = diffs.max() if len(diffs) else float('nan')
+
+        print(f"Coverage baseline min/med: {base_min:.4f}s / {base_med:.4f}s")
+        print(f"Coverage vector min/med:   {vec_min:.4f}s / {vec_med:.4f}s")
+        print(f"Coverage max abs diff: {max_diff}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.hatch.build]
 include = ["src/bagelfactor"]
+
+# uv settings (tools/uv may also be configured externally)
+[tool.uv]
+# uv's tool-specific python field isn't used in all versions; record Python compatibility here
+# for humans and tools: requires-python already set at project table.
+

--- a/src/bagelfactor/data/universe.py
+++ b/src/bagelfactor/data/universe.py
@@ -22,7 +22,8 @@ class Universe:
     def __post_init__(self) -> None:
         if not isinstance(self.mask.index, pd.MultiIndex):
             raise TypeError("Universe.mask must be indexed by (date, asset)")
-        if self.mask.index.names != ["date", "asset"]:
+        if list(self.mask.index.names) != ["date", "asset"]:
+            # normalize index names to expected order; allow None entries
             object.__setattr__(
                 self,
                 "mask",

--- a/src/bagelfactor/metrics/coverage.py
+++ b/src/bagelfactor/metrics/coverage.py
@@ -13,7 +13,5 @@ def coverage_by_date(panel: pd.DataFrame, *, column: str) -> pd.Series:
         raise KeyError(f"Missing column: {column!r}")
 
     s = panel[column]
-    def _cov(x: pd.Series) -> float:
-        return float(x.notna().mean()) if len(x) else float("nan")
-
-    return s.groupby(level="date", sort=False).apply(_cov).rename("coverage")
+    # Vectorized: compute fraction of non-NA per date using groupby mean on boolean mask
+    return s.notna().groupby(level="date", sort=False).mean().astype(float).rename("coverage")


### PR DESCRIPTION
Vectorize the IC and Coverage calculation.

- IC: ~4-5x faster (20000 rows: 0.058s → 
This pull request introduces significant performance improvements to the `ic_series` and `coverage_by_date` metrics by replacing per-group apply logic with fully vectorized implementations. It also adds a benchmarking script to compare the new vectorized methods with the previous approaches, clarifies documentation, and makes minor compatibility and usability enhancements.

**Performance improvements for metrics:**

* Refactored `ic_series` in `src/bagelfactor/metrics/ic.py` to use a vectorized, per-date correlation calculation, replacing the slower `groupby.apply` method. This change leverages group aggregations and NumPy for efficient computation, significantly improving speed.
* Refactored `coverage_by_date` in `src/bagelfactor/metrics/coverage.py` to use a vectorized calculation, replacing the previous groupby apply with a direct groupby mean on the boolean mask, improving performance.

**Benchmarking and validation:**

* Added `examples/benchmark_ic.py`, a new script that generates synthetic panels and compares the performance and results of the new vectorized implementations against the previous `groupby.apply` baselines for both IC and coverage metrics.

**Documentation and usability:**

* Updated the documentation in `docs/modules/data/universe.md` to clarify that Universe masks are reindexed to match the panel and missing entries are treated as False, preventing unintentional row drops.
* Improved the index name normalization in `src/bagelfactor/data/universe.py` to handle cases where index names may not exactly match the expected order or may contain `None` entries, increasing robustness.

**Compatibility and configuration:**

* Updated `README.md` to specify that Python >=3.12 is required.
* Added a `[tool.uv]` section to `pyproject.toml` to document Python compatibility for tools and humans.
* Added missing `numpy` import in `src/bagelfactor/metrics/ic.py` for the new vectorized logic.0.013s; 100k rows: 0.151s →
0.045s). Max abs diff ~3.7e-16 (numeric   identical).     - Coverage:
~20-30x faster (20000 rows: 0.020s → 0.0006s; 100k rows: 0.050s →
0.003s). Results identical.